### PR TITLE
doc: Mention supported plugins fb-contrib and Find Security Bugs on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/00b47dd51b964655a0329723156a3eb3)](https://www.codacy.com/gh/codacy/codacy-spotbugs?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=codacy/codacy-spotbugs&amp;utm_campaign=Badge_Grade)
 [![CircleCI](https://circleci.com/gh/codacy/codacy-spotbugs.svg?style=svg)](https://circleci.com/gh/codacy/codacy-spotbugs)
 
-This is the docker engine we use at Codacy to have [SpotBugs](https://spotbugs.github.io/) support.
+This is the docker engine we use at Codacy to have [SpotBugs](https://spotbugs.github.io/) support, including the
+plugins [FBContrib](https://github.com/mebigfatguy/fb-contrib) and [Find Security Bugs](https://find-sec-bugs.github.io/).
 
 You can also create a docker to integrate the tool and language of your choice!
 Check the **Docs** section for more information.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CircleCI](https://circleci.com/gh/codacy/codacy-spotbugs.svg?style=svg)](https://circleci.com/gh/codacy/codacy-spotbugs)
 
 This is the docker engine we use at Codacy to have [SpotBugs](https://spotbugs.github.io/) support, including the
-plugins [FBContrib](https://github.com/mebigfatguy/fb-contrib) and [Find Security Bugs](https://find-sec-bugs.github.io/).
+plugins [fb-contrib](https://github.com/mebigfatguy/fb-contrib) and [Find Security Bugs](https://find-sec-bugs.github.io/).
 
 You can also create a docker to integrate the tool and language of your choice!
 Check the **Docs** section for more information.


### PR DESCRIPTION
To make maintenance easier, I propose that we include the plugins we support on each tool directly on the `README.md` of each tool. On the documentation available on docs.codacy.com I will be directing users who want to know more details about our support for the tools to the corresponding repositories. This way it will be easier to have the information up-to-date.